### PR TITLE
Update package platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,8 @@ import PackageDescription
 
 let package = Package(
     name: "Poly",
+    platforms: [.macOS(.v10_10),
+                .iOS(.v10)],
     products: [
         .library(
             name: "Poly",


### PR DESCRIPTION
As this project is used by JSONAPI as dependency, and it can compile all the way back to iOS 10, it would be nice to add the platform requirement (the same one expressed on JSONAPI). 